### PR TITLE
Update build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools>=34.1.0", "wheel"]
+requires = ["setuptools>=34.1.0", "six", "wbia-utool", "wheel"]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,4 @@
 setuptools>=34.1.0
+six
+wbia-utool
 wheel

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
+import sys
+
 import six
 from utool import util_setup
 from setuptools import setup


### PR DESCRIPTION
- Add six and wbia-utool to build requirements

  Those are imported in setup.py and are not in the standard library so
  need to be included in the build requirements:
  
  ```
  Obtaining file:///wbia/wbia-plugin-cnn
    Installing build dependencies ... done
    Getting requirements to build wheel ... error
    ERROR: Command errored out with exit status 1:
     command: /virtualenv/env3/bin/python3 /virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpsrqc5dfs
         cwd: /wbia/wbia-plugin-cnn
    Complete output (18 lines):
    Traceback (most recent call last):
      File "/virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>
        main()
      File "/virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel
        return hook(config_settings)
      File "/tmp/pip-build-env-4qzqhyhn/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 147, in get_requires_for_build_wheel
        config_settings, requirements=['wheel'])
      File "/tmp/pip-build-env-4qzqhyhn/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 127, in _get_build_requires
        self.run_setup()
      File "/tmp/pip-build-env-4qzqhyhn/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 249, in run_setup
        self).run_setup(setup_script=setup_script)
      File "/tmp/pip-build-env-4qzqhyhn/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 142, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 4, in <module>
        import six
    ModuleNotFoundError: No module named 'six'
    ----------------------------------------
  ERROR: Command errored out with exit status 1: /virtualenv/env3/bin/python3 /virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpsrqc5dfs Check the logs for full command output.
  ```
  
  ```
      File "setup.py", line 5, in <module>
        from utool import util_setup
    ModuleNotFoundError: No module named 'utool'
    ----------------------------------------
  ERROR: Command errored out with exit status 1: /virtualenv/env3/bin/python3 /virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpmyqfcij0 Check the logs for full command output.
  ```

- Add missing "import sys" in setup.py

  ```
      File "setup.py", line 127, in <module>
        install_requires = parse_requirements('requirements/runtime.txt')
      File "setup.py", line 120, in parse_requirements
        packages = list(gen_packages_items())
      File "setup.py", line 112, in gen_packages_items
        if not sys.version.startswith('3.4'):
    NameError: name 'sys' is not defined
    ----------------------------------------
  ERROR: Command errored out with exit status 1: /virtualenv/env3/bin/python3 /virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmp6a1gk6lq Check the logs for full command output.
  ```
