### PR TITLE
Use setuptools_scm for version discovery through git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ raw_profile*
 failed_doctests.txt
 timeings.txt
 branch.sync.sh
+
+# setuptools_scm version discovery writes the version to <pkg>/_version.py
+**/_version.py

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,6 +2,8 @@ lasagne
 requests>=0.8.2; python_version < '3'
 scikit-learn>=0.16.1
 theano
+wbia-utool
+wbia-vtool
 # h5py  # Install this instead sudo apt-get install libhdf5-dev due to Numpy versioning issues
 #pylearn2
 #git+git://github.com/lisa-lab/pylearn2.git

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,4 @@
-lasagne
+git+https://github.com/Lasagne/Lasagne.git#egg=lasagne
 requests>=0.8.2; python_version < '3'
 scikit-learn>=0.16.1
 theano

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def parse_requirements(fname='requirements.txt', with_version=True):
                 yield info
         else:
             info = {'line': line}
-            if line.startswith('-e '):
+            if line.startswith('-e ') or line.startswith('git+'):
                 info['package'] = line.split('#egg=')[1]
             else:
                 # Remove versioning from the package

--- a/setup.py
+++ b/setup.py
@@ -134,13 +134,22 @@ def parse_requirements(fname='requirements.txt', with_version=True):
 
 if __name__ == '__main__':
     print('[setup] Entering IBEIS setup')
-    kwargs = util_setup.setuptools_setup(
+    kwargs = dict(
         setup_fpath=__file__,
         name='wbia_cnn',
         # author='Hendrik Weideman, Jason Parham, and Jon Crall',
         # author_email='erotemic@gmail.com',
         packages=util_setup.find_packages(),
-        version=util_setup.parse_package_for_version('wbia_cnn'),
+        # --- VERSION ---
+        # The following settings retreive the version from git.
+        # See https://github.com/pypa/setuptools_scm/ for more information
+        setup_requires=['setuptools_scm'],
+        use_scm_version={
+            'write_to': 'wbia_cnn/_version.py',
+            'write_to_template': '__version__ = "{version}"',
+            'tag_regex': '^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$',
+            'local_scheme': 'dirty-tag',
+        },
         license=util_setup.read_license('LICENSE'),
         long_description=util_setup.parse_readme('README.md'),
         ext_modules=util_setup.find_ext_modules(),

--- a/wbia_cnn/__init__.py
+++ b/wbia_cnn/__init__.py
@@ -16,7 +16,10 @@ from wbia_cnn import theano_ext
 # from wbia_cnn import _plugin
 print, print_, profile = ut.inject2(__name__, '[wbia_cnn]')
 
-__version__ = '1.0.0.dev1'
+try:
+    from wbia_cnn._version import __version__
+except ImportError:
+    __version__ = '0.0.0'
 
 
 def reassign_submodule_attributes(verbose=True):


### PR DESCRIPTION
- Use setuptools_scm for version discovery through git

  This pulls the version information from git. It also writes the
  version to file for non-git distribution of the code (e.g. wheel).

- Add wbia-utool and wbia-vtool to requirements/runtime.txt

  `utool` and `vtool` are imported all over the codebase so it should be
  included in the requirements.

- Install github version of lasagne in runtime requirements

  When the pypi version of lasagne (v0.1) is installed, we get this error:
  
  ```
  $ python -c 'import wbia_cnn'
  WARNING (theano.tensor.blas): Using NumPy C-API based implementation for BLAS functions.
  Lasagne failed to import
  cannot import name 'downsample' from 'theano.tensor.signal' (/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/theano/tensor/signal/__init__.py)
  Traceback (most recent call last):
    File "/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/wbia_cnn/__LASAGNE__.py", line 9, in <module>
      from lasagne import *  # NOQA
    File "/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/lasagne/__init__.py", line 19, in <module>
      from . import layers
    File "/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/lasagne/layers/__init__.py", line 7, in <module>
      from .pool import *
    File "/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/lasagne/layers/pool.py", line 6, in <module>
      from theano.tensor.signal import downsample
  ImportError: cannot import name 'downsample' from 'theano.tensor.signal' (/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/theano/tensor/signal/__init__.py)
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/wbia_cnn/__init__.py", line 9, in <module>
      from wbia_cnn import __LASAGNE__
    File "/home/karen/src/wildbook/wbia-plugin-cnn/wheelhouse/py3/lib/python3.8/site-packages/wbia_cnn/__LASAGNE__.py", line 13, in <module>
      print('theano.__version__ = %r' % (theano.__version__,))
  AttributeError: module 'wbia_cnn.__THEANO__' has no attribute '__version__'
  ```
  
  It seems that lasagne v0.1 is not compatible with theano >0.7.  There's
  no newer versions on pypi for lasagne, but there's active development on
  github, so the only thing we can do is to install the github version of
  lasagne.
