### PR TITLE
Include Lasagne in the wbia-cnn package

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           # This allows the setuptools_scm library to discover the tag version from git
           fetch-depth: 0
+          submodules: 'true'
 
       - uses: actions/setup-python@v2
         name: Install Python
@@ -42,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Lasagne"]
+	path = Lasagne
+	url = https://github.com/Lasagne/Lasagne.git

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,4 @@
-git+https://github.com/Lasagne/Lasagne.git#egg=lasagne
+# lasagne  # Use the one embedded here instead because the pypi version is too old
 requests>=0.8.2; python_version < '3'
 scikit-learn>=0.16.1
 theano

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,8 @@ if __name__ == '__main__':
         name='wbia_cnn',
         # author='Hendrik Weideman, Jason Parham, and Jon Crall',
         # author_email='erotemic@gmail.com',
-        packages=util_setup.find_packages(),
+        packages=util_setup.find_packages() + ['lasagne'],
+        package_dir={'lasagne': 'Lasagne/lasagne'},
         # --- VERSION ---
         # The following settings retreive the version from git.
         # See https://github.com/pypa/setuptools_scm/ for more information


### PR DESCRIPTION
- Add https://github.com/Lasagne/Lasagne as a submodule

  Lasagne hasn't been releasing to pypi and we don't want to install using
  `git+https://github.com/Lasagne/Lasagne` because it seems you can't mix
  it with `pip install wbia-cnn`.  There's some restrictions on having
  dependencies that are not on pypi.
  
  Instead, we'll bundle Lasagne into `wbia-cnn`.

- Include Lasagne in the wbia-cnn package

  So the wbia-cnn wheel will now include `wbia_cnn` and `lasagne`.
  We can stop relying on the pypi version of Lasagne and use this version
  instead.
